### PR TITLE
Akashic Tome config update - add The One Probe, Compact Machines, and Cyclic things

### DIFF
--- a/Configs/akashictome.cfg
+++ b/Configs/akashictome.cfg
@@ -15,6 +15,12 @@ general {
         roots:runedTablet
         opencomputers:tool:4
         immersiveengineering:tool:3
+        draconicevolution:info_tablet
+        integrateddynamics:on_the_dynamics_of_integration
+        thaumcraft:thaumonomicon
+        theoneprobe:probenote
+        compactmachines3:psd
+        cyclicmagic:tool_trade
      >
     S:"Whitelisted Names" <
         book


### PR DESCRIPTION
Adds The One Probe's note, Compact Machines PSD (which doubles as the guide book) and Cyclic's Merchant Almanac to Akashic Tome's whitelist